### PR TITLE
Maintain consistency between models for long-term-planning

### DIFF
--- a/rvo2AI/src/RVO2DAIModule.cpp
+++ b/rvo2AI/src/RVO2DAIModule.cpp
@@ -74,7 +74,7 @@ void RVO2DAIModule::init( const SteerLib::OptionDictionary & options, SteerLib::
 	logStats = false;
 	gShowAllStats = false;
 	logFilename = "rvo2AI.log";
-	dont_plan=false;
+	dont_plan=true;
 
 	rvo_max_neighbors = MAX_NEIGHBORS;
 	rvo_max_speed = MAX_SPEED;


### PR DESCRIPTION
Keep either all models as waymarks, or all without, for better consistency. This method keeps all without by default. (Changes RVO to not use waymarks)